### PR TITLE
only-failed is not a valid option for list-suites and list-tests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,14 +37,14 @@ inputs:
     description: |
       Limits which test suites are listed. Supported options:
         - all
-        - only-failed
+        - failed
     required: true
     default: 'all'
   list-tests:
     description: |
       Limits which test cases are listed. Supported options:
         - all
-        - only-failed
+        - failed
         - none
     required: true
     default: 'all'


### PR DESCRIPTION
Fix for https://github.com/phoenix-actions/test-reporting/issues/29

`only-failed` is listed as a valid input but later on while parsing the inputs only `failed` is accepted.

https://github.com/phoenix-actions/test-reporting/blob/main/src/main.ts#L50-L51