### PR TITLE
Fix bug for missing test suite for innnerSuite

### DIFF
--- a/src/parsers/mochawesome-json/mochawesome-json-parser.ts
+++ b/src/parsers/mochawesome-json/mochawesome-json-parser.ts
@@ -81,21 +81,22 @@ export class MochawesomeJsonParser implements TestParser {
     }
 
     // Handle nested suites
-    const processNestedSuites = (suite: MochawesomeJsonSuite, nestedSuiteIndex: number, suiteName: string): void => {
+    const processNestedSuites = (suite: MochawesomeJsonSuite, suiteName: string): void => {
       // Process suite tests
       processAllTests(suite.tests, suiteName)
 
-      for (const innerSuite of suite.suites) {
+      for (const childSuite of suite.suites) {
         // Process inner suite tests
-        processAllTests(innerSuite.tests, suiteName)
+        if (childSuite.tests.length > 0) {
+          processAllTests(childSuite.tests, suiteName)
+        }
 
-        if (innerSuite?.suites[nestedSuiteIndex]?.suites.length > 0) {
-          processNestedSuites(innerSuite, 0, suiteName)
-        } else {
-          processAllTests(innerSuite?.suites[nestedSuiteIndex]?.tests, suiteName)
-          nestedSuiteIndex++
-
-          // TODO - Figure out how to get 1.1.1.1.2 - suites with more than one object in them
+        for (const grandChildSuite of childSuite.suites) {
+          if (grandChildSuite?.suites.length > 0) {
+            processNestedSuites(childSuite, suiteName)
+          } else {
+            processAllTests(grandChildSuite.tests, suiteName)
+          }
         }
       }
     }
@@ -114,7 +115,7 @@ export class MochawesomeJsonParser implements TestParser {
       // Process tests that are in a suite
       if (suites?.length > 0) {
         for (const suite of suites) {
-          processNestedSuites(suite, 0, filePath ? filePath : suite.title)
+          processNestedSuites(suite, filePath ? filePath : suite.title)
         }
       }
     }


### PR DESCRIPTION
Function was incrementing the index in foreach, which was skipping to next test for the next suite and not current one. Use double for loop to properly step through each test within each suite.