### PR TITLE
fix: propagate the fail-on-error settings to the step conslusion

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -140,7 +140,7 @@ class TestReporter {
     }
 
     const isFailed = results.some(tr => tr.result === 'failed')
-    const conclusion = isFailed ? 'failure' : 'success'
+    const conclusion = this.failOnError && isFailed ? 'failure' : 'success'
     const passed = results.reduce((sum, tr) => sum + tr.passed, 0)
     const failed = results.reduce((sum, tr) => sum + tr.failed, 0)
     const skipped = results.reduce((sum, tr) => sum + tr.skipped, 0)


### PR DESCRIPTION
Context:

The `fail-on-error` setting toggle on/off the fact that the action should fail if reporter see failed test in report.

If one set `fail-on-error` to false, the expected behaviour is that the step should be considered successful.

Proposal:
Here is the proposal to set the conlusion accordingly
- 'failure' if report sense failed tests and 'fail-on-error' is 'true' or missing (true by default)
- 'success' if there are no failed test or 'fail-on-error' is set to 'false'